### PR TITLE
FIX: active threads height, hover

### DIFF
--- a/src/addons/channel-indicators/_index.scss
+++ b/src/addons/channel-indicators/_index.scss
@@ -42,7 +42,6 @@
         border-radius: var(--indicator-rounding-info);
         &::before {
             content: "";
-            border-left: var(--indicator-border-info) transparent;
         }
     }
     .containerDefault-YUSmu3 .wrapper-NhbLHG, .channel-1Shao0 {
@@ -62,7 +61,7 @@
 /* [ INDICATORS ] */
     /* [ HOVERED ] */
     [class="iconVisibility-vptxma wrapper-NhbLHG"], .modeMuted-2T4MDZ, .modeUnread-3Cxepe,
-    .container-1oeRFJ.clickable-28SzVr {
+    .container-1oeRFJ.clickable-28SzVr, .wrapper-NhbLHG {
         &:hover {
             background: var(--indicator-hovered);
             div > svg {

--- a/src/addons/channel-indicators/_index.scss
+++ b/src/addons/channel-indicators/_index.scss
@@ -92,7 +92,7 @@
     .modeUnread-3Cxepe {
         background-color: var(--indicator-unread-background);
         &::before {
-            border-left-color: var(--indicator-unread-border);
+            border-left: var(--indicator-border-info) var(--indicator-unread-border);
         }
         .overflow-1wOqNV {
             color: var(--indicator-active);

--- a/src/support/compiled.css
+++ b/src/support/compiled.css
@@ -966,7 +966,6 @@ base0F  #b9b9bc  Deprecated, Opening/Closing Embedded Language Tags, e.g. <?php 
 }
 #app-mount .wrapper-NhbLHG::before, #app-mount .channel-1Shao0::before, #app-mount .categoryItem-Kc_HK_::before {
     content: "";
-    border-left: var(--indicator-border-info) transparent;
 }
 #app-mount .containerDefault-YUSmu3 .wrapper-NhbLHG::before, #app-mount .channel-1Shao0::before {
     position: absolute;
@@ -1009,7 +1008,7 @@ base0F  #b9b9bc  Deprecated, Opening/Closing Embedded Language Tags, e.g. <?php 
     background-color: var(--indicator-unread-background);
 }
 #app-mount .modeUnread-3Cxepe::before {
-    border-left-color: var(--indicator-unread-border);
+    border-left: var(--indicator-border-info) var(--indicator-unread-border);
 }
 #app-mount .modeUnread-3Cxepe .overflow-1wOqNV {
     color: var(--indicator-active);


### PR DESCRIPTION
The theme had an annoying height issue with the active threads tab due to a useless border-left being added to it.
![DiscordCanary_DoILcYquMr](https://user-images.githubusercontent.com/52982404/150651755-c748401c-6d39-4841-b739-771a34522775.gif)

This PR removes that border left, and makes the hover event the same with other channels.
![DiscordCanary_teveYYNkzt](https://user-images.githubusercontent.com/52982404/150651783-7b056ccc-4f8b-4f75-8acc-cee791df3e29.gif)
 